### PR TITLE
Add possibility to change app's stack

### DIFF
--- a/app.go
+++ b/app.go
@@ -120,6 +120,12 @@ func (a *App) SetHead(head string) (*App, error) {
 	return a, nil
 }
 
+// SetStack sets the application's stack
+func (a *App) SetStack(stack string) (*App, error) {
+	a.Stack = stack
+	return a.StoreAttrs()
+}
+
 // StoreAttrs saves the current App attrs.
 func (a *App) StoreAttrs() (*App, error) {
 	f, err := a.dir.GetFile("attrs", new(cp.JsonCodec))
@@ -352,10 +358,10 @@ func getApp(name string, s cp.Snapshotable) (*App, error) {
 	sp := s.GetSnapshot()
 	app := storeFromSnapshotable(s).NewApp(name, "", "")
 
-	f, err := sp.GetFile(app.dir.Prefix("attrs"), new(cp.JsonCodec))
+	f, err := sp.GetSnapshot().GetFile(app.dir.Prefix("attrs"), new(cp.JsonCodec))
 	if err != nil {
 		if cp.IsErrNoEnt(err) {
-			err = errorf(ErrNotFound, `app "%s" not found`, name)
+			err = errorf(ErrNotFound, `app "%s" not found`, app.Name)
 		}
 		return nil, err
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -33,8 +33,8 @@ func appSetup(name string) (*Store, *App) {
 	return s, app
 }
 
-func TestAppRegistration(t *testing.T) {
-	_, app := appSetup("lolcatapp")
+func registerApp(t *testing.T, name string) (*Store, *App, error) {
+	s, app := appSetup(name)
 
 	check, _, err := app.GetSnapshot().Exists(app.dir.Name)
 	if err != nil {
@@ -45,11 +45,37 @@ func TestAppRegistration(t *testing.T) {
 	}
 
 	app, err = app.Register()
+	return s, app, err
+}
+
+func TestUpdateStack(t *testing.T) {
+	s, app, err := registerApp(t, "jdk-8-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app, err = app.SetStack("jdk-8")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app, err = s.GetApp("jdk-8-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if app.Stack != "jdk-8" {
+		t.Error("stack was not changed successfully")
+	}
+}
+
+func TestAppRegistration(t *testing.T) {
+	_, app, err := registerApp(t, "lolcatapp")
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	check, _, err = app.GetSnapshot().Exists(app.dir.Name)
+	check, _, err := app.GetSnapshot().Exists(app.dir.Name)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
We started to build custom stacks so that we don't have to bundle all
the runtimes on every bazooka build. We will adjusts projects over time
to use specialized stacks. For this to work, we need the possibility to
change an app's stack.

@grobie 