### PR TITLE
Add LogPersistence attribute to proc

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -29,7 +29,8 @@ type Proc struct {
 
 // Mutable extra Proc attributes.
 type ProcAttrs struct {
-	Limits ResourceLimits `json:"limits"`
+	Limits         ResourceLimits `json:"limits"`
+	LogPersistence bool           `json:"log_persistence"`
 }
 
 // Per-proc resource limits.

--- a/proc_test.go
+++ b/proc_test.go
@@ -315,4 +315,20 @@ func TestProcAttributes(t *testing.T) {
 	if *proc.Attrs.Limits.MemoryLimitMb != memoryLimitMb {
 		t.Fatalf("MemoryLimitMb does not contain the value that was set")
 	}
+
+	// LogPersistence
+	if proc.Attrs.LogPersistence != false {
+		t.Fatal("LogPersistence should be off by default")
+	}
+	proc.Attrs.LogPersistence = true
+	if _, err := proc.StoreAttrs(); err != nil {
+		t.Fatal(err)
+	}
+	proc, err = app.GetProc("web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proc.Attrs.LogPersistence != true {
+		t.Fatalf("LogPersistence should be on after change")
+	}
 }


### PR DESCRIPTION
In order to control the bazooka-pm configured logging. Some services
don't require log archiving and should be able to disable it altogether.