### PR TITLE
Bump Visor SchemaVersion

### DIFF
--- a/visor.go
+++ b/visor.go
@@ -8,16 +8,17 @@ package visor
 import (
 	"errors"
 	"fmt"
-	cp "github.com/soundcloud/cotterpin"
 	"net"
 	"path"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	cp "github.com/soundcloud/cotterpin"
 )
 
-const SchemaVersion = 4
+const SchemaVersion = 5
 
 const (
 	DefaultUri     = "doozer:?ca=localhost:8046"


### PR DESCRIPTION
The new LogPersistence proc flag requires a schema bump, so that old
clients don't remove the attribute from the attributes object, and
therefore, reset the flag to false.