### PR TITLE
Introduce TrafficControl for procs

### DIFF
--- a/error.go
+++ b/error.go
@@ -20,6 +20,7 @@ var (
 	ErrInvalidKey      = errors.New("invalid key")
 	ErrInvalidState    = errors.New("invalid state")
 	ErrInvalidFile     = errors.New("invalid file")
+	ErrInvalidShare    = errors.New("invalid share")
 	ErrBadProcName     = errors.New("invalid proc type name: only alphanumeric chars allowed")
 	ErrUnauthorized    = errors.New("operation is not permitted")
 	ErrNotFound        = errors.New("object not found")
@@ -91,6 +92,11 @@ func IsErrInvalidArgument(err error) bool {
 // IsErrInvalidKey is a helper to test for ErrInvalidKey.
 func IsErrInvalidKey(err error) bool {
 	return unwrapErr(err) == ErrInvalidKey
+}
+
+// IsErrInvalidShare is a helper to test for ErrInvalidShare.
+func IsErrInvalidShare(err error) bool {
+	return unwrapErr(err) == ErrInvalidShare
 }
 
 func errorf(err error, format string, args ...interface{}) *Error {


### PR DESCRIPTION
For some notion of control over how much traffic a proc should receive this change introduces a new port per proc which can be used to communicate the intended traffic share in percentage.

Along with that new unique port per proc comes another configurable called TrafficControl. Which is meant to be `nil` if control should be tuned off and the proc should get full traffic. When set it contains a single field called Share and must be a positive integer between 0 and 100. The Share set will be communicate over some simple protocol via the ControlPort.

* add ControlPort to proc
* add TrafficControl attribute to proc
* emit event when proc attrs change

***
@soundcloud/iss 