### PR TITLE
Avoid partial writes to instances

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -328,13 +328,18 @@ func (i *Instance) Restarted(restarts InsRestarts) (*Instance, error) {
 	//           start    = 10.0.0.1 24691 localhost
 	// +         restarts = 1 0
 	//
-	if i.Status != InsStatusRunning {
-		return i, nil
-	}
-
 	sp, err := i.GetSnapshot().FastForward()
 	if err != nil {
 		return i, err
+	}
+
+	i, err = getInstance(i.ID, sp)
+	if err != nil {
+		return nil, err
+	}
+
+	if i.Status != InsStatusRunning {
+		return i, nil
 	}
 
 	f := cp.NewFile(i.dir.Prefix(restartsPath), nil, new(cp.ListIntCodec), sp)
@@ -358,10 +363,20 @@ func (i *Instance) Stop() error {
 	//           ...
 	// +         stop =
 	//
+	sp, err := i.GetSnapshot().FastForward()
+	if err != nil {
+		return err
+	}
+
+	i, err = getInstance(i.ID, sp)
+	if err != nil {
+		return err
+	}
+
 	if i.Status != InsStatusRunning {
 		return ErrInvalidState
 	}
-	_, err := i.dir.Set("stop", "")
+	_, err = i.dir.Set(stopPath, "")
 	if err != nil {
 		return err
 	}

--- a/instance_test.go
+++ b/instance_test.go
@@ -289,6 +289,16 @@ func TestInstanceStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	err = ins.Unregister("test-suite", fmt.Errorf("cleanup"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ins.Stop()
+	if !IsErrNotFound(err) {
+		t.Errorf("have %v, want %v", err, ErrNotFound)
+	}
 	// Note: we aren't checking that the files are created in the coordinator,
 	// that is better tested via events in event.go, as we don't want to couple
 	// the tests with the schema.
@@ -363,6 +373,16 @@ func TestInstanceRestarted(t *testing.T) {
 	}
 	if ins3.Restarts.Fail != 2 {
 		t.Error("expected restart count to be set to 2")
+	}
+
+	err = ins1.Unregister("test-bot", fmt.Errorf("cleanup"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ins1.Restarted(InsRestarts{0, 3})
+	if have, want := err, ErrNotFound; !IsErrNotFound(err) {
+		t.Errorf("have %v, want %v", have, want)
 	}
 }
 


### PR DESCRIPTION
In order to avoid data corruption on instance sub-tress this change explicitely pulls down the latest state from the datastore.

***
@soundcloud/iss 