### PR TITLE
Fix emission of early EvInsReg

### DIFF
--- a/event.go
+++ b/event.go
@@ -83,7 +83,7 @@ const (
 	pathRev
 	pathProc
 	pathProcAttrs
-	pathIns
+	pathInsRegistered
 	pathInsStatus
 	pathInsStart
 	pathInsStop
@@ -94,7 +94,7 @@ var eventPatterns = map[*regexp.Regexp]eventPath{
 	regexp.MustCompile("^/apps/(" + charPat + "+)/revs/(" + charPat + "+)/registered$"):  pathRev,
 	regexp.MustCompile("^/apps/(" + charPat + "+)/procs/(" + charPat + "+)/registered$"): pathProc,
 	regexp.MustCompile("^/apps/(" + charPat + "+)/procs/(" + charPat + "+)/attrs$"):      pathProcAttrs,
-	regexp.MustCompile("^/instances/([-0-9]+)/object$"):                                  pathIns,
+	regexp.MustCompile("^/instances/([-0-9]+)/registered$"):                              pathInsRegistered,
 	regexp.MustCompile("^/instances/([-0-9]+)/status$"):                                  pathInsStatus,
 	regexp.MustCompile("^/instances/([-0-9]+)/start$"):                                   pathInsStart,
 	regexp.MustCompile("^/instances/([-0-9]+)/stop$"):                                    pathInsStop,
@@ -247,7 +247,7 @@ func enrichEvent(src *cp.Event, s cp.Snapshotable) (event *Event, err error) {
 				if src.IsSet() {
 					etype = EvProcAttrs
 				}
-			case pathIns:
+			case pathInsRegistered:
 				uncanonicalized.Instance = &match[1]
 
 				if src.IsSet() {


### PR DESCRIPTION
Up until now the crucial registration event for instances was fired when a Set on /instances/$id/object was observed. As this is not the last file written for an instance there is a window where the event is observed and the event tries to provide a complete Instance object from the partially written instance sub-tree.

To avoid this error case we listen now on the last path written and emit when we can be sure that the entire instance sub-tree is present. This relies on a stable order of file creation during RegisterInstance.

***
@soundcloud/iss 