### PR TITLE
Fix WatchInstanceStart for unclaimed instances

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -316,6 +316,16 @@ func TestEventInstanceStateChange(t *testing.T) {
 
 	go storeFromSnapshotable(ins).WatchEvent(l)
 
+	if _, err = ins.Claim("0.0.0.0"); err != nil {
+		t.Fatal(err)
+	}
+
+	ins, err = ins.Unclaim("0.0.0.0")
+	if err != nil {
+		t.Error(err)
+	}
+	expectEvent(EvInsUnclaim, ins, l, t)
+
 	if _, err = ins.Claim(ip); err != nil {
 		t.Fatal(err)
 	}

--- a/instance.go
+++ b/instance.go
@@ -925,9 +925,11 @@ func (s *Store) GetLostInstances() ([]*Instance, error) {
 func (s *Store) WatchInstanceStart(listener chan *Instance, errors chan error) {
 	eventc := make(chan *Event)
 	go func() {
-		listener <- (<-eventc).Source.(*Instance)
+		for {
+			listener <- (<-eventc).Source.(*Instance)
+		}
 	}()
-	if err := s.WatchEvent(eventc, EvInsReg); err != nil {
+	if err := s.WatchEvent(eventc, EvInsReg, EvInsUnclaim); err != nil {
 		errors <- err
 	}
 }


### PR DESCRIPTION
The method WatchInstanceStart method handles previously claimed tickets
again. This change also fixes a regression bug introduced in af69061,
where WatchInstanceStart would only handle a single event and block
afterwards.

@beorn7 