### PR TITLE
Fix getting the restart count.

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -692,7 +692,7 @@ func (i *Instance) claimed(ip string) {
 func (i *Instance) getRestarts() (InsRestarts, *cp.File, error) {
 	var restarts InsRestarts
 
-	f, err := i.dir.GetFile(i.dir.Prefix(restartsPath), new(cp.ListIntCodec))
+	f, err := i.dir.GetFile(restartsPath, new(cp.ListIntCodec))
 	if err == nil {
 		fields := f.Value.([]int)
 

--- a/instance_test.go
+++ b/instance_test.go
@@ -379,6 +379,32 @@ func TestInstanceRestarted(t *testing.T) {
 	}
 }
 
+func TestInstanceRestartAndGet(t *testing.T) {
+
+	s := instanceSetup()
+	ip := "10.0.0.1"
+	ins := instanceSetupClaimed("fat-pat", ip)
+
+	ins, err := ins.Started(ip, "fat-pat.com", 9999, 10000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ins.Restarted(InsRestarts{0, 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ins1, err := s.GetInstance(ins.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ins1.Restarts.Fail != 1 {
+		t.Errorf("restarts: got %v, want 1", ins1.Restarts.Fail)
+	}
+}
+
 func TestInstanceFailed(t *testing.T) {
 	ip := "10.0.0.1"
 	ins := instanceSetupClaimed("fat-cat", ip)


### PR DESCRIPTION
This bug was introduced in 1fa25bc. The `dir` already handles the prefix.

Add a test case to check actually getting the restart count from the storage.

@grobie 