### PR TITLE
Fix instance WaitFailed

### DIFF
--- a/instance_test.go
+++ b/instance_test.go
@@ -633,6 +633,9 @@ func TestInstanceWaitFailed(t *testing.T) {
 	if want, have := InsStatusFailed, ins.Status; want != have {
 		t.Errorf("want status %s, have %s", want, have)
 	}
+	if want, have := "fail test", ins.Termination.Reason; want != have {
+		t.Errorf("want reason '%s', have '%s'", want, have)
+	}
 }
 
 func TestInstanceWaitUnregister(t *testing.T) {


### PR DESCRIPTION
So far (Instance) WaitFailed() only updated the Status attribute, but
not the Termination attribute. As the latter includes the actually
interesting reason for a failure, this change updates that information
as well now. In order to do that, the Wait method had to be changed to
wait for all path updates exercised by Failed().