### PR TITLE
Improve error message of GetRevision

### DIFF
--- a/revision.go
+++ b/revision.go
@@ -123,7 +123,14 @@ func getRevision(app *App, ref string, s cp.Snapshotable) (*Revision, error) {
 	f, err := r.dir.GetFile(archiveURLPath, new(cp.StringCodec))
 	if err != nil {
 		if cp.IsErrNoEnt(err) {
-			err = errorf(ErrNotFound, "archive-url not found for %s:%s", app.Name, ref)
+			exists, _, err := s.GetSnapshot().Exists(r.dir.Name)
+			if err != nil {
+				return nil, err
+			}
+			if !exists {
+				return nil, errorf(ErrNotFound, `revision "%s" not found for app %s`, ref, app.Name)
+			}
+			return nil, errorf(ErrNotFound, "archive-url not found for %s:%s", app.Name, ref)
 		}
 		return nil, err
 	}

--- a/revision_test.go
+++ b/revision_test.go
@@ -89,3 +89,16 @@ func TestRevisionUnregister(t *testing.T) {
 		t.Error("Revision still registered")
 	}
 }
+
+func TestRevisionGet(t *testing.T) {
+	_, app := revSetup()
+
+	_, err := app.GetRevision("unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown revision")
+	}
+	want := `revision "unknown" not found for app rev-test`
+	if have := err.Error(); want != have {
+		t.Errorf("want error '%s', have '%s'", want, have)
+	}
+}


### PR DESCRIPTION
The current error message was pretty low level and not very user
friendly for the most common use case: the revision was simply missing.