### PR TITLE
Tags

### DIFF
--- a/app.go
+++ b/app.go
@@ -24,7 +24,6 @@ type App struct {
 	Name       string
 	RepoURL    string
 	Stack      string
-	Head       string
 	Env        map[string]string
 	DeployType string
 	Registered time.Time
@@ -109,18 +108,6 @@ func (a *App) Unregister() error {
 		return errorf(ErrNotFound, `app "%s" not found`, a)
 	}
 	return a.dir.Join(sp).Del("/")
-}
-
-// SetHead sets the application's latest revision
-func (a *App) SetHead(head string) (*App, error) {
-	d, err := a.dir.Set("head", head)
-	if err != nil {
-		return nil, err
-	}
-	a.Head = head
-	a.dir = d
-
-	return a, nil
 }
 
 // SetStack sets the application's stack
@@ -372,13 +359,6 @@ func getApp(name string, s cp.Snapshotable) (*App, error) {
 	app.RepoURL = value["repo-url"].(string)
 	app.Stack = value["stack"].(string)
 	app.DeployType = value["deploy-type"].(string)
-
-	f, err = sp.GetFile(app.dir.Prefix("head"), new(cp.StringCodec))
-	if err == nil {
-		app.Head = f.Value.(string)
-	} else if cp.IsErrNoEnt(err) {
-		err = nil
-	}
 
 	f, err = app.dir.GetFile(registeredPath, new(cp.StringCodec))
 	if err != nil {

--- a/error.go
+++ b/error.go
@@ -24,6 +24,7 @@ var (
 	ErrBadProcName     = errors.New("invalid proc type name: only alphanumeric chars allowed")
 	ErrUnauthorized    = errors.New("operation is not permitted")
 	ErrNotFound        = errors.New("object not found")
+	ErrTagShadowing    = errors.New("revision already exists with tag name")
 )
 
 // Error is the wrapper type to express custom errors.
@@ -97,6 +98,11 @@ func IsErrInvalidKey(err error) bool {
 // IsErrInvalidShare is a helper to test for ErrInvalidShare.
 func IsErrInvalidShare(err error) bool {
 	return unwrapErr(err) == ErrInvalidShare
+}
+
+// IsErrTagShadowing is a helper to test for ErrTagShadowing.
+func IsErrTagShadowing(err error) bool {
+	return unwrapErr(err) == ErrTagShadowing
 }
 
 func errorf(err error, format string, args ...interface{}) *Error {

--- a/revision.go
+++ b/revision.go
@@ -7,10 +7,13 @@ package visor
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	cp "github.com/soundcloud/cotterpin"
 )
+
+var RefFormat = regexp.MustCompile(`^[[:alnum:]\-\.]+$`)
 
 // A Revision represents an application revision,
 // identifiable by its `ref`.

--- a/tag.go
+++ b/tag.go
@@ -1,0 +1,166 @@
+package visor
+
+import (
+	"time"
+
+	cp "github.com/soundcloud/cotterpin"
+)
+
+const (
+	tagsPath = "tags"
+)
+
+// Tag represents a human readable alias for a revision. It's analogous to a
+// branch in git referencing a specific commit. It's possible that multiple
+// tags reference the same revision.
+type Tag struct {
+	file       *cp.File
+	App        *App      `json:"-"`
+	Name       string    `json:"name"`
+	Ref        string    `json:"ref"`
+	Registered time.Time `json:"registered"`
+}
+
+// NewTag returns a named Tag referencing a given ref.
+func (a *App) NewTag(name, ref string) *Tag {
+	return &Tag{
+		file: cp.NewFile(
+			a.dir.Prefix(tagsPath, name),
+			nil,
+			new(cp.JsonCodec), a.GetSnapshot(),
+		),
+		App:  a,
+		Name: name,
+		Ref:  ref,
+	}
+}
+
+// GetSnapshot satisfies the cp.Snapshotable interface.
+func (t *Tag) GetSnapshot() cp.Snapshot {
+	return t.file.Snapshot
+}
+
+// Register stores the Tag in store. It does permit overwriting an existing tag
+// with the same name to enable atomic updates.
+func (t *Tag) Register() error {
+	var err error
+
+	revs, err := t.App.GetRevisions()
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for _, r := range revs {
+		if r.Ref == t.Name {
+			return errorf(ErrTagShadowing, `revision already exists with tag name "%s"`, t.Name)
+		}
+		if r.Ref == t.Ref {
+			found = true
+		}
+	}
+	if !found {
+		return errorf(ErrNotFound, `revision "%s" not found for app "%s"`, t.Ref, t.App.Name)
+	}
+
+	t.Registered = time.Now()
+	t.file, err = t.file.Set(t)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Unregister removes the stored Tag from store.
+func (t *Tag) Unregister() error {
+	sp, err := t.GetSnapshot().FastForward()
+	if err != nil {
+		return err
+	}
+	exists, _, err := sp.Exists(t.file.Path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return errorf(ErrNotFound, `tag "%s" not found`, t.Name)
+	}
+	return t.file.Del()
+}
+
+// GetTag retrieves the Tag with the given name.
+func (a *App) GetTag(name string) (*Tag, error) {
+	sp, err := a.GetSnapshot().FastForward()
+	if err != nil {
+		return nil, err
+	}
+	return getTag(a, name, sp)
+}
+
+// GetTags returns a list of all Tags for the app.
+func (a *App) GetTags() ([]*Tag, error) {
+	sp, err := a.GetSnapshot().FastForward()
+	if err != nil {
+		return nil, err
+	}
+
+	names, err := sp.Getdir(a.dir.Prefix(tagsPath))
+	if err != nil {
+		return nil, err
+	}
+
+	tags := []*Tag{}
+	ch, errch := cp.GetSnapshotables(names, func(name string) (cp.Snapshotable, error) {
+		return getTag(a, name, sp)
+	})
+	for i := 0; i < len(names); i++ {
+		select {
+		case t := <-ch:
+			tags = append(tags, t.(*Tag))
+		case err := <-errch:
+			return nil, err
+		}
+	}
+	return tags, nil
+}
+
+// LookupRevision retrieves a revision by ref or tag.
+func (a *App) LookupRevision(ref string) (*Revision, error) {
+	sp, err := a.GetSnapshot().FastForward()
+	if err != nil {
+		return nil, err
+	}
+
+	rev, rerr := getRevision(a, ref, sp)
+	if rerr != nil && !IsErrNotFound(rerr) {
+		return nil, rerr
+	}
+	if rev != nil {
+		return rev, nil
+	}
+	tag, err := getTag(a, ref, sp)
+	if err != nil && !IsErrNotFound(err) {
+		return nil, err
+	}
+	if tag == nil {
+		return nil, rerr
+	}
+	return getRevision(a, tag.Ref, sp)
+}
+
+func getTag(a *App, name string, s cp.Snapshotable) (*Tag, error) {
+	t := &Tag{}
+	c := &cp.JsonCodec{DecodedVal: t}
+
+	f, err := s.GetSnapshot().GetFile(a.dir.Prefix(tagsPath, name), c)
+	if err != nil {
+		if cp.IsErrNoEnt(err) {
+			err = errorf(ErrNotFound, `tag "%s" not found`, name)
+		}
+		return nil, err
+	}
+
+	t.file = f
+	t.App = a
+
+	return t, nil
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,182 @@
+package visor
+
+import "testing"
+
+func TestTagRegister(t *testing.T) {
+	var (
+		app  = tagSetup(t)
+		name = "register"
+		ref1 = "123abcd"
+		ref2 = "d1324cs"
+		rev1 = tagStore.NewRevision(app, ref1, "http://unknown")
+		rev2 = tagStore.NewRevision(app, ref2, "http://unknown")
+	)
+
+	for _, rev := range []*Revision{rev1, rev2} {
+		if _, err := rev.Register(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// test precondition
+	if _, err := app.GetTag(name); !IsErrNotFound(err) {
+		t.Fatal("want GetTag to fail for unregistered tag")
+	}
+
+	// test registration of unknown revision
+	if err := app.NewTag(name, "unknw13").Register(); !IsErrNotFound(err) {
+		t.Fatal("want Register to fail for unknown revision")
+	}
+
+	// test valid registration
+	if err := app.NewTag(name, ref1).Register(); err != nil {
+		t.Fatal("want Register to succeed, have %v", err)
+	}
+	tag, err := app.GetTag(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag.Name != name {
+		t.Errorf("want tag name %s, have %s", name, tag.Name)
+	}
+	if tag.Ref != ref1 {
+		t.Errorf("want tag ref %s, have %s", ref1, tag.Ref)
+	}
+	if tag.App.Name != app.Name {
+		t.Errorf("want tag app %s, have %s", app.Name, tag.App.Name)
+	}
+
+	// test re-registration of existing name
+	tag.Ref = ref2
+	if err := tag.Register(); err != nil {
+		t.Fatal(err)
+	}
+	tag, err = app.GetTag(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag.Ref != ref2 {
+		t.Errorf("want tag ref %s, have %s", ref2, tag.Ref)
+	}
+
+	// test shadowing of existing revision name
+	if err := app.NewTag(ref1, ref1).Register(); !IsErrTagShadowing(err) {
+		t.Errorf("want tag shadowing error, have %v", err)
+	}
+}
+
+func TestTagUnregister(t *testing.T) {
+	var (
+		app  = tagSetup(t)
+		name = "unregister"
+		ref  = "u123abd"
+		tag  = app.NewTag(name, ref)
+		rev  = tagStore.NewRevision(app, ref, "http://unknown")
+	)
+
+	if err := tag.Unregister(); !IsErrNotFound(err) {
+		t.Fatal("want Unregister to fail for unregistered tag")
+	}
+	if _, err := rev.Register(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tag.Register(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.GetTag(name); err != nil {
+		t.Fatal(err)
+	}
+	if err := tag.Unregister(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.GetTag(name); !IsErrNotFound(err) {
+		t.Fatal("want GetTag fail for unregistered tag")
+	}
+}
+
+func TestTagList(t *testing.T) {
+	app := tagSetup(t)
+	rev := tagStore.NewRevision(app, "adf3kk3h", "")
+	tags := []*Tag{
+		app.NewTag("foo", rev.Ref),
+		app.NewTag("bar", rev.Ref),
+		app.NewTag("baz", rev.Ref),
+	}
+
+	if _, err := rev.Register(); err != nil {
+		t.Fatal(rev)
+	}
+
+	for _, tag := range tags {
+		if err := tag.Register(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tags1, err := app.GetTags()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != len(tags1) {
+		t.Error("GetTags didn't return correct amount of tags")
+	}
+}
+
+func TestTagLookup(t *testing.T) {
+	var (
+		app  = tagSetup(t)
+		name = "lookup"
+		ref1 = "lup1234"
+		ref2 = "lup9876"
+		rev1 = tagStore.NewRevision(app, ref1, "http://unknown")
+		rev2 = tagStore.NewRevision(app, ref2, "http://unknown")
+	)
+
+	for _, rev := range []*Revision{rev1, rev2} {
+		if _, err := rev.Register(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := app.NewTag(name, ref1).Register(); err != nil {
+		t.Fatal(t)
+	}
+
+	if _, err := app.LookupRevision(name); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.LookupRevision(ref2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.LookupRevision("unknown"); !IsErrNotFound(err) {
+		t.Fatal("want lookup to fail for unknown revision")
+	}
+}
+
+var tagStore *Store
+
+func tagSetup(t *testing.T) *App {
+	if tagStore == nil {
+		s, err := DialURI(DefaultURI, "/tag-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		tagStore = s
+	}
+
+	err := tagStore.reset()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tagStore, err = tagStore.FastForward()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tagStore, err = tagStore.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tagStore.NewApp("tag-test", "git://tag.git", "tags")
+}


### PR DESCRIPTION
In order to provide stable identifiers for revisions, tags get
introduced which are analogous to branch names in git. The main use case
will be stack names, where tags will allow maintainers of stacks to
iterate over new revisions without the need to update all apps each
time.

Tags replace the concept of app.Head which fulfilled a similar use case.